### PR TITLE
Add encryption service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,278 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@aws-crypto/cache-material": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/cache-material/-/cache-material-1.0.4.tgz",
+      "integrity": "sha512-RkW6eOI6LYNSltsh6JR681VH/Y+Pg/pvMh7lWW8si+6QmnEVFiRKeJDB15suQb+MZIm+7mCjMEiA8C5TWNcIpg==",
+      "requires": {
+        "@aws-crypto/material-management": "^1.0.4",
+        "@aws-crypto/serialize": "^1.0.4",
+        "@types/lru-cache": "^5.1.0",
+        "lru-cache": "^5.1.1",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        }
+      }
+    },
+    "@aws-crypto/caching-materials-manager-node": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/caching-materials-manager-node/-/caching-materials-manager-node-1.0.5.tgz",
+      "integrity": "sha512-OXeL4n97w3/QNd5wPeEWAMnWO5eBSMoOjXDA/KyCuRv7uRhgz3x1mYOu98f08LOeQaWop26CMN6K9kIbO9Vk2w==",
+      "requires": {
+        "@aws-crypto/cache-material": "^1.0.4",
+        "@aws-crypto/material-management-node": "^1.0.5",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        }
+      }
+    },
+    "@aws-crypto/client-node": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/client-node/-/client-node-1.0.5.tgz",
+      "integrity": "sha512-PXiZv7UTO7o5FKzehSmMFFcJgFhkFrwVN9PEyjUovb7ynD3+MxUfhAaXSSRQg+VSrSwU3ySr/u6WtJHxpnOkhA==",
+      "requires": {
+        "@aws-crypto/caching-materials-manager-node": "^1.0.5",
+        "@aws-crypto/decrypt-node": "^1.0.5",
+        "@aws-crypto/encrypt-node": "^1.0.5",
+        "@aws-crypto/kms-keyring-node": "^1.0.5",
+        "@aws-crypto/material-management-node": "^1.0.5",
+        "@aws-crypto/raw-aes-keyring-node": "^1.0.5",
+        "@aws-crypto/raw-rsa-keyring-node": "^1.1.2",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        }
+      }
+    },
+    "@aws-crypto/decrypt-node": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/decrypt-node/-/decrypt-node-1.0.5.tgz",
+      "integrity": "sha512-IUzhJTGQKXntKSBxUkQw5aBlGirsp7VQ7EBpbku5zcIAuVVtHC5qDg2men+FiQ6YjmBZ5B1AfFYreX+iHV6jIA==",
+      "requires": {
+        "@aws-crypto/material-management-node": "^1.0.5",
+        "@aws-crypto/serialize": "^1.0.4",
+        "@types/duplexify": "^3.6.0",
+        "duplexify": "^4.1.1",
+        "readable-stream": "^3.6.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        }
+      }
+    },
+    "@aws-crypto/encrypt-node": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/encrypt-node/-/encrypt-node-1.0.5.tgz",
+      "integrity": "sha512-r5gdEfevRe39mLcTuBAalt5yiTNTszhTy2Tg0WaVvMzW8komyykN3TZq65gqGl0+ZEsZ69MYDBZ+yv7T97Fh9A==",
+      "requires": {
+        "@aws-crypto/material-management-node": "^1.0.5",
+        "@aws-crypto/serialize": "^1.0.4",
+        "@types/duplexify": "^3.6.0",
+        "duplexify": "^4.1.1",
+        "readable-stream": "^3.6.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        }
+      }
+    },
+    "@aws-crypto/hkdf-node": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/hkdf-node/-/hkdf-node-1.0.3.tgz",
+      "integrity": "sha512-qR7qsjXa0LWXTesiaUtZpoVJmFGbqogbVyZwHGWF/jU9VvewjnBzNzEIBjVElPvI3AKgY5Wj2yKxjcbI8gdERw==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        }
+      }
+    },
+    "@aws-crypto/kms-keyring": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring/-/kms-keyring-1.1.1.tgz",
+      "integrity": "sha512-ur4Me2xxPCiLTYLLKdLORvC/mmq+SROcdJApeOF8eqdq+UScG5fxbEPM8q+ei/bE65p/YvtVH27XE6eRFMyNEQ==",
+      "requires": {
+        "@aws-crypto/material-management": "^1.0.4",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        }
+      }
+    },
+    "@aws-crypto/kms-keyring-node": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring-node/-/kms-keyring-node-1.0.5.tgz",
+      "integrity": "sha512-EoEV3pjpzjkCDZf3njbD4Se1C6t0ObZNumxxXH0ezSu/AzjSmdkrYdKPW0YWzzkQRxEgOIQdbsIJcDkJysiDww==",
+      "requires": {
+        "@aws-crypto/kms-keyring": "^1.1.1",
+        "@aws-crypto/material-management-node": "^1.0.5",
+        "aws-sdk": "^2.650.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        }
+      }
+    },
+    "@aws-crypto/material-management": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management/-/material-management-1.0.4.tgz",
+      "integrity": "sha512-ltptElApgDpP4UfDy8+mdzNjOt46tHJKFvwSfwQywd8FGTSs2YRlp4LxPB5gAYHsYhJ+YA+AEbc5tiEdio8VRA==",
+      "requires": {
+        "asn1.js": "^5.3.0",
+        "bn.js": "^5.1.1",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        }
+      }
+    },
+    "@aws-crypto/material-management-node": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management-node/-/material-management-node-1.0.5.tgz",
+      "integrity": "sha512-d+lfcAKTrfSQ7c94K8WDxBrEoX4QGH863cjuQ0Y7V7Hh5N+QjBfsGGwNG8ErMnDAKjo/nT86yKN4L8WxbiGD2g==",
+      "requires": {
+        "@aws-crypto/hkdf-node": "^1.0.3",
+        "@aws-crypto/material-management": "^1.0.4",
+        "@aws-crypto/serialize": "^1.0.4",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        }
+      }
+    },
+    "@aws-crypto/raw-aes-keyring-node": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-aes-keyring-node/-/raw-aes-keyring-node-1.0.5.tgz",
+      "integrity": "sha512-yTlTuiDkIZa2LVaqcxTxT773V0nkwxUqpZJvV2RzWu8FRX5wprrKzy1o2Ccd+7jfvPjVdRG7JJ/XDqd1N04qUQ==",
+      "requires": {
+        "@aws-crypto/material-management-node": "^1.0.5",
+        "@aws-crypto/raw-keyring": "^1.0.4",
+        "@aws-crypto/serialize": "^1.0.4",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        }
+      }
+    },
+    "@aws-crypto/raw-keyring": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-keyring/-/raw-keyring-1.0.4.tgz",
+      "integrity": "sha512-+EMu5vdtUR7nMOt+20MHE1Xr74XFuj3ynC5VkQg2I8LQelM4uHo22xp0ucyquaokg2NfvywNPy85jnpv7NDXEQ==",
+      "requires": {
+        "@aws-crypto/material-management": "^1.0.4",
+        "@aws-crypto/serialize": "^1.0.4",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        }
+      }
+    },
+    "@aws-crypto/raw-rsa-keyring-node": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-rsa-keyring-node/-/raw-rsa-keyring-node-1.1.2.tgz",
+      "integrity": "sha512-67EVs3JRi+7AA5uAORUHH0qlgvd/UVdYkQ9LLI/iGhamS27mBOich2+tKNS6EPhuGPVAp2+c3kJOWkXWUbTXWA==",
+      "requires": {
+        "@aws-crypto/material-management-node": "^1.0.5",
+        "@aws-crypto/raw-keyring": "^1.0.4",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        }
+      }
+    },
+    "@aws-crypto/serialize": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/serialize/-/serialize-1.0.4.tgz",
+      "integrity": "sha512-pGOOui1IJKE63IQ6ddD1iRE1M7NCvoLi0p2Z/a6OIgY35fljBnVQT2QcGG/Oa364ikc+mrgTgCG1f+TifPu/rA==",
+      "requires": {
+        "@aws-crypto/material-management": "^1.0.4",
+        "asn1.js": "^5.3.0",
+        "bn.js": "^5.1.1",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
@@ -71,6 +343,14 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
+    "@types/duplexify": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@types/duplexify/-/duplexify-3.6.0.tgz",
+      "integrity": "sha512-5zOA53RUlzN74bvrSGwjudssD9F3a797sDZQkiYpUOxW+WHaXTCPz4/d5Dgi6FKnOqZ2CpaTo0DhgIfsXAOE/A==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -101,6 +381,11 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/lru-cache": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.0.tgz",
+      "integrity": "sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w=="
     },
     "@types/nconf": {
       "version": "0.10.0",
@@ -483,6 +768,24 @@
         }
       }
     },
+    "asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "requires": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+        }
+      }
+    },
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -499,11 +802,32 @@
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
+    "aws-sdk": {
+      "version": "2.723.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.723.0.tgz",
+      "integrity": "sha512-GmyMacu1x1BOA8tYZuZS1DKcdn7QQX+DJFdFgZ3IilMzlX3cdinMXkBc5onEnhbwHx657XHoPigJynTRGGNuWQ==",
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "bintrees": {
       "version": "1.0.1",
@@ -540,6 +864,11 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
+    "bn.js": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
+      "integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -548,6 +877,16 @@
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "buffer-more-ints": {
@@ -816,6 +1155,17 @@
         "esutils": "^2.0.2"
       }
     },
+    "duplexify": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.1.tgz",
+      "integrity": "sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==",
+      "requires": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      }
+    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -828,6 +1178,14 @@
       "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
       "requires": {
         "env-variable": "0.0.x"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "requires": {
+        "once": "^1.4.0"
       }
     },
     "env-variable": {
@@ -1409,6 +1767,11 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
     "external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -1616,6 +1979,11 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "ignore": {
       "version": "4.0.6",
@@ -1862,6 +2230,11 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2003,11 +2376,24 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "requires": {
+        "yallist": "^3.0.2"
+      }
+    },
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
+    },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -2342,7 +2728,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -2621,6 +3006,11 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
     "querystringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
@@ -2737,8 +3127,12 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "secure-keys": {
       "version": "1.0.0",
@@ -3200,6 +3594,11 @@
         "standard-engine": "^12.0.0"
       }
     },
+    "stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -3602,6 +4001,22 @@
         "punycode": "^2.1.0"
       }
     },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        }
+      }
+    },
     "url-parse": {
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
@@ -3615,6 +4030,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "v8-compile-cache": {
       "version": "2.1.1",
@@ -3733,8 +4153,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",
@@ -3744,6 +4163,20 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xtend": {
       "version": "4.0.2",
@@ -3755,6 +4188,11 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+    },
+    "yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yargs": {
       "version": "3.32.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dist": "npm run build && cd dist && npm publish"
   },
   "dependencies": {
+    "@aws-crypto/client-node": "^1.0.5",
     "@types/amqp-connection-manager": "^2.0.10",
     "@types/flat": "^5.0.1",
     "@types/logfmt": "^1.2.1",

--- a/src/encryption/index.ts
+++ b/src/encryption/index.ts
@@ -1,0 +1,62 @@
+
+import Logger from '../logger'
+import config from '../config'
+import * as AWS from '@aws-crypto/client-node'
+
+export declare type EncryptionContext = {
+  [index: string]: string;
+};
+
+const logger = Logger('encryption')
+
+interface Encryption {
+  encrypt: (plaintext: string, context: EncryptionContext) => Promise<string>
+  decrypt: (ciphertext: string, context: EncryptionContext) => Promise<string>
+}
+
+const newKeyring = (conf: any): AWS.KeyringNode => {
+  if (!conf || !conf.generatorKeyId || !conf.keyIds) {
+    const error = new Error('INVALID_ENCRYPTION_CONFIG')
+    logger.error('Verify AWS Encryption keys configuration', {}, error)
+    throw error
+  }
+
+  const generatorKeyId = conf.generatorKeyId
+  const keyIds = conf.keyIds
+  const keyring = new AWS.KmsKeyringNode({ generatorKeyId, keyIds })
+  return keyring
+}
+
+const encryption = (configName: string): Encryption => {
+  const conf = config.get(configName)
+  const keyring = newKeyring(conf)
+
+  const encrypt = async (plaintext: string, context: EncryptionContext): Promise<string> => {
+    const { result } = await AWS.encrypt(keyring, plaintext, { encryptionContext: context })
+    return result.toString('base64')
+  }
+
+  const decrypt = async (ciphertext: string, context: EncryptionContext) : Promise<string> => {
+    const buff = Buffer.from(ciphertext, 'base64')
+    const { plaintext, messageHeader } = await AWS.decrypt(keyring, buff)
+    const { encryptionContext } = messageHeader
+
+    Object.entries(context).forEach(([key, value]) => {
+      if (encryptionContext[key] !== value) {
+        const error = new Error('Encryption Context does not match expected values')
+        logger.error('Encrypted message is corrupted or untrustworthy', context, error)
+        throw error
+      }
+    })
+
+    return plaintext.toString()
+  }
+
+  return {
+    encrypt,
+    decrypt
+  }
+}
+
+export type { Encryption }
+export default encryption

--- a/src/encryption/index.ts
+++ b/src/encryption/index.ts
@@ -15,14 +15,14 @@ interface Encryption {
 }
 
 const newKeyring = (conf: any): AWS.KeyringNode => {
-  if (!conf || !conf.generatorKeyId || !conf.keyIds) {
+  if (!conf || !conf.generator_key_id || !conf.key_ids) {
     const error = new Error('INVALID_ENCRYPTION_CONFIG')
     logger.error('Verify AWS Encryption keys configuration', {}, error)
     throw error
   }
 
-  const generatorKeyId = conf.generatorKeyId
-  const keyIds = conf.keyIds
+  const generatorKeyId = conf.generator_key_id
+  const keyIds : string[] = conf.key_ids.split(',')
   const keyring = new AWS.KmsKeyringNode({ generatorKeyId, keyIds })
   return keyring
 }


### PR DESCRIPTION
### Summary

This PR adds the encryption service using the AWS Encryption SDK, enabling encryption and decryption without the need to share keys.

It is necessary to set a master key or CMM as described in [AWS documentation](https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/how-it-works.html).

A sample of the configuration required is:
####  config. json
```json
{ 
  "aws": {
    "generator_key_id" :"<generatorKeyId>",
    "key_ids": "<keyID>"
  }
}
```
#### env vars
```shell
aws__generator_key_id='<generatorKeyId>'
aws__key_ids='<keyID>'
```

### Tests
It's tested in a mock project using in it as a local dependency using `npm link`.