### PR TITLE
Remove deprecated crypto dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1080,11 +1080,6 @@
         "which": "^2.0.1"
       }
     },
-    "crypto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
-      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig=="
-    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@types/verror": "^1.10.4",
     "amqp-connection-manager": "^3.2.0",
     "amqplib": "^0.5.6",
-    "crypto": "^1.0.1",
     "flat": "^5.0.0",
     "logfmt": "^1.3.2",
     "nconf": "^0.10.0",

--- a/src/cryptic/index.ts
+++ b/src/cryptic/index.ts
@@ -1,4 +1,4 @@
-const crypto = require('crypto')
+import * as crypto from 'crypto'
 
 interface CrypticResponse {
   iv: string,


### PR DESCRIPTION
### Summary
This PR removes the deprecated 'crypto' dependency as this is now a built-in Node module as defined in the [documentation](https://www.npmjs.com/package/crypto) . 
