### PR TITLE
[LOG-409] Add request logger with masked fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,95 @@
-# elementals
+# Elementals
 Building blocks for NodeJS services
+
+
+## Logger
+
+### Requests
+
+To log HTTP requests and mask sensitive information:
+
+``` js
+logger.request(message, data, maskedFields)
+```
+
+`maskedFields` is a list of name fields to be masked, it's possible to mask nested JSON by using the field.subfield notation.
+
+#### Examples
+
+- Plain (Depth 0)
+
+  ``` js
+  const maskedFields = ['client']
+  logger.request('Incoming request', {base: 'POST /jobs/', client:'<test>', body:... }, maskedFields)
+  ```
+  Result
+  ``` log
+  {
+      "message": "Incoming request,
+      "data": {
+          "base": "POST /jobs/",
+          "client": "*****",
+          "body": {
+              ...
+          }
+      }
+  }
+  ```
+- Nested Fields
+
+  Example data request:
+  ``` js
+  data = {
+        baseUrl: 'POST /jobs/',
+        client: '<test>',
+        body: {
+          client_reference: '<ref_test>',
+          origin: {
+            name: 'Store',
+            ...
+          }
+        }
+  ```
+  - Depth 1
+    ``` js
+    const maskedFields = ['body.origin']
+    logger.request('Incoming request', data, maskedFields)
+    ```
+    Result
+    ``` log
+    {
+        "message": "Incoming request,
+        "data": {
+            "base": "POST /jobs/",
+            "client": "<test>",
+            "body": {
+                "client_reference": "<ref_test>",
+                "origin": "*******"
+                ...
+            }
+        }
+    }
+    ```
+
+  - Depth 2
+    ``` js
+    const maskedFields = ['body.origin.name']
+    logger.request('Incoming request', data, maskedFields)
+    ```
+    Result
+    ``` log
+    {
+        "message": "Incoming request,
+        "data": {
+            "base": "POST /jobs/",
+            "client": "<test>",
+            "body": {
+                "client_reference": "<ref_test>",
+                "origin":{
+                  "name": "*****",
+                }
+                ...
+            }
+        }
+    }
+    ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -5878,11 +5878,21 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -5970,6 +5980,15 @@
       "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
+      }
+    },
+    "maskdata": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/maskdata/-/maskdata-1.1.2.tgz",
+      "integrity": "sha512-T46cFM6GZ8616sycYk/W9TnaRaczsmbxH0gqi+ug5B3kIITWdyDi+oVvnJfAjeEsrw7N9zoGwU1r+dlcPAsy1A==",
+      "requires": {
+        "lodash.get": "^4.4.2",
+        "lodash.set": "^4.3.2"
       }
     },
     "merge-stream": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "amqplib": "^0.5.6",
     "flat": "^5.0.0",
     "logfmt": "^1.3.2",
+    "maskdata": "^1.1.2",
     "nconf": "^0.10.0",
     "node-schedule": "^1.3.2",
     "prom-client": "^11.5.3",

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -5,10 +5,12 @@ import flat from 'flat'
 import config from '../config'
 const { combine, timestamp, label, printf, colorize, json } = format
 
+const maskData = require('maskdata')
 const level = config.get('log_level') || 'debug'
 const logFormat = config.get('log_format')
 const maxDepth = config.get('log_max_depth') ?? 3
 const silent = config.get('log_silent') || false
+const maskSymbol = config.get('mask_symbol') ?? '*'
 
 export const formats = (tag: string) => {
   return {
@@ -32,10 +34,19 @@ export const formats = (tag: string) => {
   }
 }
 
+const maskRequestData = (input: JSON, maskedFields: string []) => {
+  const maskJSONOptions = {
+    maskWith: maskSymbol,
+    fields: maskedFields
+  }
+  return maskData.maskJSONFields(input, maskJSONOptions)
+}
+
 interface Logger {
   debug: (message: string, data?: any) => void
   info: (message: string, data?: any) => void
   error: (message: string, data: any, err: any) => void
+  request: (message: string, data: any, maskedFields?: string[]) => void
 }
 
 const logger = (tag: string): Logger => {
@@ -57,7 +68,13 @@ const logger = (tag: string): Logger => {
   const debug = (message: string, data?: any) => {
     log.debug(message, { data })
   }
-  return { debug, info, error }
+  const request = (message: string, data: any, maskedFields?: string[]) => {
+    if (maskedFields) {
+      data = maskRequestData(data, maskedFields)
+    }
+    log.info(message, { data })
+  }
+  return { debug, info, error, request }
 }
 
 export default logger

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -1,0 +1,103 @@
+import Logger from '../src/logger'
+import { info } from 'winston'
+
+jest.mock('winston', () => {
+  const mFormat = {
+    combine: jest.fn(),
+    timestamp: jest.fn(),
+    printf: jest.fn(),
+    label: jest.fn(),
+    colorize: jest.fn(),
+    json: jest.fn()
+  }
+  const mTransports = {
+    Console: jest.fn(),
+    File: jest.fn()
+  }
+
+  const mInfo = jest.fn()
+
+  const mLogger = {
+    info: mInfo
+  }
+
+  return {
+    format: mFormat,
+    transports: mTransports,
+    createLogger: jest.fn(() => mLogger),
+    info: mInfo
+  }
+})
+
+describe('Request Logger', () => {
+  const logger = Logger('test')
+  let data: any
+
+  beforeEach(() => {
+    data = {
+      baseUrl: 'POST /jobs/',
+      client: 'TEST',
+      body: {
+        client_reference: 'JU_TEST',
+        recipient: {
+          name: 'Test Cliente',
+          email: 'test@instaleap.io',
+          phone_number: '123456789',
+          identification: {
+            type: 'PASS',
+            number: 'AS1123'
+          }
+        },
+        origin: {
+          name: 'Store',
+          address: 'Calle 123',
+          address_two: 'Parque la 93',
+          country: 'Colombia',
+          city: 'Bogota',
+          state: 'Cundinamarca',
+          zip_code: '57'
+        }
+      }
+    }
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should mask the request data with depth 0', () => {
+    const maskedFields = ['client']
+    const expectedData = data
+    expectedData.client = '*'.repeat(data.client.length)
+    logger.request('Incoming request', data, maskedFields)
+    expect(info).toBeCalled()
+    expect(info).toBeCalledWith('Incoming request', { data: expectedData })
+  })
+
+  it('should mask the request data with depth 1', () => {
+    const maskedFields = ['body.client_reference']
+    const expectedData = data
+    expectedData.body.client_reference = '*'.repeat(data.body.client_reference.length)
+    logger.request('Incoming request', data, maskedFields)
+    expect(info).toBeCalled()
+    expect(info).toBeCalledWith('Incoming request', { data: expectedData })
+  })
+
+  it('should mask the request data with depth 2', () => {
+    const maskedFields = ['body.recipient.identification']
+    const expectedData = data
+    expectedData.body.recipient.identification = '*'.repeat(data.body.recipient.identification.length)
+    logger.request('Incoming request', data, maskedFields)
+    expect(info).toBeCalled()
+    expect(info).toBeCalledWith('Incoming request', { data: expectedData })
+  })
+
+  it('should mask the request data with depth 3', () => {
+    const maskedFields = ['body.recipient.identification.number']
+    const expectedData = data
+    expectedData.body.recipient.identification.number = '*'.repeat(data.body.recipient.identification.number.length)
+    logger.request('Incoming request', data, maskedFields)
+    expect(info).toBeCalled()
+    expect(info).toBeCalledWith('Incoming request', { data: expectedData })
+  })
+})


### PR DESCRIPTION
### Summary

This PR adds a requests logger to mask sensitive information. `maskedFields` is a list of name fields to be masked, it's possible to mask nested JSON by using the field.subfield notation.

#### Usage

  Example data request:
  ``` js
  data = {
        baseUrl: 'POST /jobs/',
        client: '<test>',
        body: {
          client_reference: '<ref_test>',
          origin: {
            name: 'Store',
            ...
          }
        }
  ```

  ``` js
    const maskedFields = ['body.origin.name']
    logger.request('Incoming request', data, maskedFields)
 ```
Result
 ``` log
    {
        "message": "Incoming request,
        "data": {
            "base": "POST /jobs/",
            "client": "<test>",
            "body": {
                "client_reference": "<ref_test>",
                "origin":{
                  "name": "*****",
                }
                ...
            }
        }
    }
  ```

### Tests
Unit test added for Logger.
