### PR TITLE
Exporting Publisher interface

### DIFF
--- a/src/rabbitmq/index.ts
+++ b/src/rabbitmq/index.ts
@@ -95,7 +95,7 @@ interface ConsumerOptions extends Options.Consume {
   prefetch?: number
 }
 
-interface Publisher {
+export interface Publisher {
   publish: (routingKey: string, data: any, options?: Options.Publish) => Promise<void>
 }
 


### PR DESCRIPTION
We need the interface type of the publishers to allow nullable variables. Ex:
```Typescript
let publisher: Publisher | null = null;
```